### PR TITLE
Update for container image vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build
 RUN dotnet publish --runtime alpine-x64 -c Release -o out --self-contained true /p:PublishTrimmed=true
 
 # build runtime image
-FROM cingulara/openrmf-base:1.04.00
+FROM cingulara/openrmf-base:1.08.02
 RUN apk update && apk upgrade
 
 RUN mkdir /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-msg-compliance"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.00
+VERSION ?= 1.08.01
 NAME ?= "openrmf-msg-compliance"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/src/Classes/CCIListGenerator.cs
+++ b/src/Classes/CCIListGenerator.cs
@@ -17,7 +17,6 @@ namespace openrmf_msg_compliance.Classes
       /// <returns>The list of CCIs matching the control passed in</returns>
       public static List<string> GetCCIListing(string control, List<CciItem> cciItems)
       {
-        try {
           // find all records where the NIST control is in the CciReference and add the parent CCI
           // return the list of strings
           List<string> cciList = new List<string>();
@@ -28,11 +27,6 @@ namespace openrmf_msg_compliance.Classes
           }
 
           return cciList.Distinct().ToList();
-        }
-        catch (Exception ex) {
-            // log it here
-            throw ex;
-        }
       }
     }
 }

--- a/src/openrmf-msg-compliance.csproj
+++ b/src/openrmf-msg-compliance.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_compliances</RootNamespace>
     <ProjectGuid>{516d0f13-fd17-4a4a-91bd-c97bf4697101}</ProjectGuid>
-    <Version>1.08.01</Version>
+    <Version>1.08.02</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Messaging API for sending Compliance data via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 

--- a/src/openrmf-msg-compliance.csproj
+++ b/src/openrmf-msg-compliance.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_compliances</RootNamespace>
     <ProjectGuid>{516d0f13-fd17-4a4a-91bd-c97bf4697101}</ProjectGuid>
-    <Version>1.08.00</Version>
+    <Version>1.08.01</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Messaging API for sending Compliance data via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 

--- a/src/openrmf-msg-compliance.csproj
+++ b/src/openrmf-msg-compliance.csproj
@@ -23,6 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Commits on Aug 28, 2022
[update to latest base image](https://github.com/Cingulara/openrmf-msg-compliance/commit/b2717e1b97413c674317f8dcc32748b55eb48c80)

Commits on Nov 27, 2022
[updating vulnerability information for v1.8.3](https://github.com/Cingulara/openrmf-msg-compliance/commit/c5cbec9eedb53012bff63f03367a4cae1b0ad18d)